### PR TITLE
feat(Facade): expose caster physics cast on facade - fixes #10

### DIFF
--- a/Runtime/SharedResources/Scripts/PointerConfigurator.cs
+++ b/Runtime/SharedResources/Scripts/PointerConfigurator.cs
@@ -81,6 +81,14 @@
         }
 
         /// <summary>
+        /// Configures the physics raycast rules based on the facade settings.
+        /// </summary>
+        public virtual void ConfigureRaycastRules()
+        {
+            Caster.PhysicsCast = Facade.RaycastRules;
+        }
+
+        /// <summary>
         /// Configures the object follow sources based on the facade settings.
         /// </summary>
         public virtual void ConfigureFollowSources()

--- a/Runtime/SharedResources/Scripts/PointerFacade.cs
+++ b/Runtime/SharedResources/Scripts/PointerFacade.cs
@@ -7,6 +7,7 @@
     using Malimbe.XmlDocumentationAttribute;
     using UnityEngine;
     using Zinnia.Action;
+    using Zinnia.Cast;
     using Zinnia.Data.Attribute;
     using Zinnia.Pointer;
     using Zinnia.Rule;
@@ -62,6 +63,12 @@
         [Serialized, Cleared]
         [field: DocumentedByXml]
         public RuleContainer TargetValidity { get; set; }
+        /// <summary>
+        /// Allows to optionally define the rules for the raycast of the pointer beam elements.
+        /// </summary>
+        [Serialized, Cleared]
+        [field: DocumentedByXml]
+        public PhysicsCast RaycastRules { get; set; }
         #endregion
 
         #region Pointer Events
@@ -175,6 +182,15 @@
         protected virtual void OnAfterTargetValidityChange()
         {
             Configuration.ConfigureTargetValidity();
+        }
+
+        /// <summary>
+        /// Called after <see cref="RaycastRules"/> has been changed.
+        /// </summary>
+        [CalledAfterChangeOf(nameof(RaycastRules))]
+        protected virtual void OnAfterRaycastRulesChange()
+        {
+            Configuration.ConfigureRaycastRules();
         }
     }
 }


### PR DESCRIPTION
The internal caster contains a PhysicsCast property that allows the
rules of the raycast to be changed. This property is now exposed on
the Facade to make it easier to discover and change.