### PR TITLE
fix(Configurator): ensure custom raycast rules are set up on enable

### DIFF
--- a/Runtime/SharedResources/Scripts/PointerConfigurator.cs
+++ b/Runtime/SharedResources/Scripts/PointerConfigurator.cs
@@ -208,6 +208,7 @@
         protected virtual void OnEnable()
         {
             ConfigureTargetValidity();
+            ConfigureRaycastRules();
             ConfigureFollowSources();
             ConfigureSelectionType();
         }


### PR DESCRIPTION
The Raycast Rules option on the Facade was not being set up in the
Configurator when the script became enabled so the actual custom
rules were not being copied down to the lower elements that require
the rule.