### PR TITLE
fix(Prefabs): send top level GameObject as event source

### DIFF
--- a/Runtime/Prefabs/Indicators.ObjectPointers.Curved.prefab
+++ b/Runtime/Prefabs/Indicators.ObjectPointers.Curved.prefab
@@ -180,6 +180,7 @@ MonoBehaviour:
   selectionMethod: 0
   targetValidity:
     field: {fileID: 0}
+  raycastRules: {fileID: 0}
   Activated:
     m_PersistentCalls:
       m_Calls: []
@@ -544,16 +545,6 @@ PrefabInstance:
       propertyPath: m_Name
       value: ObjectPointer.Internal
       objectReference: {fileID: 0}
-    - target: {fileID: 6670911739145006535, guid: b5bcf67f1f80d1a4f800327247af655a,
-        type: 3}
-      propertyPath: caster
-      value: 
-      objectReference: {fileID: 8391352710448912418}
-    - target: {fileID: 6670911739145006535, guid: b5bcf67f1f80d1a4f800327247af655a,
-        type: 3}
-      propertyPath: facade
-      value: 
-      objectReference: {fileID: 2402421270702372836}
     - target: {fileID: 333590899294449391, guid: b5bcf67f1f80d1a4f800327247af655a,
         type: 3}
       propertyPath: m_LocalPosition.x
@@ -609,6 +600,16 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 6670911739145006535, guid: b5bcf67f1f80d1a4f800327247af655a,
+        type: 3}
+      propertyPath: caster
+      value: 
+      objectReference: {fileID: 8391352710448912418}
+    - target: {fileID: 6670911739145006535, guid: b5bcf67f1f80d1a4f800327247af655a,
+        type: 3}
+      propertyPath: facade
+      value: 
+      objectReference: {fileID: 2402421270702372836}
     - target: {fileID: 1639799280548245475, guid: b5bcf67f1f80d1a4f800327247af655a,
         type: 3}
       propertyPath: Appeared.m_PersistentCalls.m_Calls.Array.size
@@ -689,6 +690,11 @@ PrefabInstance:
       propertyPath: Appeared.m_PersistentCalls.m_Calls.Array.data[0].m_Arguments.m_BoolArgument
       value: 1
       objectReference: {fileID: 0}
+    - target: {fileID: 1639799280548245475, guid: b5bcf67f1f80d1a4f800327247af655a,
+        type: 3}
+      propertyPath: eventDataOriginTransformOverride
+      value: 
+      objectReference: {fileID: 1322672732093859771}
     - target: {fileID: 2680025304086750293, guid: b5bcf67f1f80d1a4f800327247af655a,
         type: 3}
       propertyPath: elements.Array.size

--- a/Runtime/Prefabs/Indicators.ObjectPointers.Straight.prefab
+++ b/Runtime/Prefabs/Indicators.ObjectPointers.Straight.prefab
@@ -172,7 +172,7 @@ GameObject:
   - component: {fileID: 3718142488040735482}
   - component: {fileID: 2748488038835702461}
   m_Layer: 0
-  m_Name: ObjectPointer.Straight
+  m_Name: Indicators.ObjectPointers.Straight
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
@@ -213,6 +213,7 @@ MonoBehaviour:
   selectionMethod: 0
   targetValidity:
     field: {fileID: 0}
+  raycastRules: {fileID: 0}
   Activated:
     m_PersistentCalls:
       m_Calls: []
@@ -466,16 +467,6 @@ PrefabInstance:
       propertyPath: facade
       value: 
       objectReference: {fileID: 2748488038835702461}
-    - target: {fileID: 2680025304086750293, guid: b5bcf67f1f80d1a4f800327247af655a,
-        type: 3}
-      propertyPath: elements.Array.size
-      value: 2
-      objectReference: {fileID: 0}
-    - target: {fileID: 2680025304086750293, guid: b5bcf67f1f80d1a4f800327247af655a,
-        type: 3}
-      propertyPath: elements.Array.data[1]
-      value: 
-      objectReference: {fileID: 2560080792642705176}
     - target: {fileID: 1639799280548245475, guid: b5bcf67f1f80d1a4f800327247af655a,
         type: 3}
       propertyPath: Appeared.m_PersistentCalls.m_Calls.Array.size
@@ -556,6 +547,21 @@ PrefabInstance:
       propertyPath: destination
       value: 
       objectReference: {fileID: 303670441478350932}
+    - target: {fileID: 1639799280548245475, guid: b5bcf67f1f80d1a4f800327247af655a,
+        type: 3}
+      propertyPath: eventDataOriginTransformOverride
+      value: 
+      objectReference: {fileID: 4333620153645678103}
+    - target: {fileID: 2680025304086750293, guid: b5bcf67f1f80d1a4f800327247af655a,
+        type: 3}
+      propertyPath: elements.Array.size
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 2680025304086750293, guid: b5bcf67f1f80d1a4f800327247af655a,
+        type: 3}
+      propertyPath: elements.Array.data[1]
+      value: 
+      objectReference: {fileID: 2560080792642705176}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: b5bcf67f1f80d1a4f800327247af655a, type: 3}
 --- !u!4 &1741380858788601439 stripped

--- a/package.json
+++ b/package.json
@@ -24,9 +24,9 @@
         "url": "https://github.com/ExtendRealityLtd"
     },
     "dependencies": {
-        "io.extendreality.zinnia.unity": "1.15.0",
+        "io.extendreality.zinnia.unity": "1.16.0",
         "io.extendreality.tilia.utilities.shaders.unity": "1.0.2",
-        "io.extendreality.tilia.mutators.objectfollower.unity": "1.0.9"
+        "io.extendreality.tilia.mutators.objectfollower.unity": "1.0.10"
     },
     "files": [
         "*.md",


### PR DESCRIPTION
Zinnia 1.16.0 brings a new option to the ObjectPointer that allows the
a custom GameObject to be provided as the source of the pointer event.

Previously, this source was always the GameObject that the
ObjectPointer component was on, but this made it difficult to set rules
based around the pointers as the GameObject with the PointerFacade on
would not be the source and therefore not make it possible to simply
provide the whole pointer prefab in a rule.

This change now sets the top level GameObejct as the ObjectPointer
event source so any rule that requires to know about a pointer can
simply use the top level pointer prefab GameObject.