### PR TITLE
fix(Operation): prevent null exception if Source not set

### DIFF
--- a/Documentation/HowToGuides/Installation/README.md
+++ b/Documentation/HowToGuides/Installation/README.md
@@ -64,5 +64,5 @@ The package will now also show up in the Unity Package Manager UI. From then on 
 [Unity Package Manager]: https://docs.unity3d.com/Manual/upm-ui.html
 [Project-Manifest]: https://docs.unity3d.com/Manual/upm-manifestPrj.html
 [Version-Release]: https://img.shields.io/github/release/ExtendRealityLtd/Tilia.Indicators.ObjectPointers.Unity.svg
-[Releases]: ../../releases
-[Latest-Release]: ../../releases/latest
+[Releases]: ../../../../../releases
+[Latest-Release]: ../../../../../releases/latest

--- a/Runtime/SharedResources/Scripts/Operation/Extraction/PointerFacadeGameObjectExtractor.cs
+++ b/Runtime/SharedResources/Scripts/Operation/Extraction/PointerFacadeGameObjectExtractor.cs
@@ -77,7 +77,7 @@
         /// <inheritdoc />
         protected override GameObject ExtractValue()
         {
-            return Source.GetType() == typeof(PointerFacade) ? base.ExtractValue() : null;
+            return Source != null && Source.GetType() == typeof(PointerFacade) ? base.ExtractValue() : null;
         }
     }
 }


### PR DESCRIPTION
The Source property can be null and the Extract method can be called
which causes a null exception. This fix just checks to see if Source
is not null before attempting to extract.