### PR TITLE
feat(PointerFacade): add way to change SelectionMethod by a UnityEvent

### DIFF
--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -4,7 +4,6 @@ update_configs:
     directory: /
     update_schedule: live
     default_reviewers:
-      - bddckr
       - thestonefox
     default_labels:
       - dependency-update

--- a/Documentation/API/PointerFacade.md
+++ b/Documentation/API/PointerFacade.md
@@ -32,6 +32,7 @@ The public interface into the Pointer Prefab.
   * [OnAfterSelectionMethodChange()]
   * [OnAfterTargetValidityChange()]
   * [Select()]
+  * [SetSelectionMethod(Int32)]
 
 ## Details
 
@@ -276,9 +277,24 @@ Gets the current ObjectPointer state and emits it through [Selected].
 public virtual void Select()
 ```
 
+#### SetSelectionMethod(Int32)
+
+Sets [SelectionMethod].
+
+##### Declaration
+
+```
+public virtual void SetSelectionMethod(int selectionMethodIndex)
+```
+
+##### Parameters
+
+| Type | Name | Description |
+| --- | --- | --- |
+| System.Int32 | selectionMethodIndex | The index of the [PointerFacade.SelectionType]. |
+
 [Tilia.Indicators.ObjectPointers]: README.md
 [PointerConfigurator]: PointerConfigurator.md
-[PointerFacade.SelectionType]: PointerFacade.SelectionType.md
 [ActivationAction]: PointerFacade.md#ActivationAction
 [FollowSource]: PointerFacade.md#FollowSource
 [RaycastRules]: PointerFacade.md#RaycastRules
@@ -286,6 +302,8 @@ public virtual void Select()
 [SelectionMethod]: PointerFacade.md#SelectionMethod
 [TargetValidity]: PointerFacade.md#TargetValidity
 [Selected]: PointerFacade.md#Selected
+[SelectionMethod]: PointerFacade.md#SelectionMethod
+[PointerFacade.SelectionType]: PointerFacade.SelectionType.md
 [Inheritance]: #Inheritance
 [Namespace]: #Namespace
 [Syntax]: #Syntax
@@ -314,3 +332,4 @@ public virtual void Select()
 [OnAfterSelectionMethodChange()]: #OnAfterSelectionMethodChange
 [OnAfterTargetValidityChange()]: #OnAfterTargetValidityChange
 [Select()]: #Select
+[SetSelectionMethod(Int32)]: #SetSelectionMethodInt32

--- a/Runtime/SharedResources/Scripts/PointerFacade.cs
+++ b/Runtime/SharedResources/Scripts/PointerFacade.cs
@@ -114,6 +114,15 @@
         #endregion
 
         /// <summary>
+        /// Sets <see cref="SelectionMethod"/>.
+        /// </summary>
+        /// <param name="selectionMethodIndex">The index of the <see cref="SelectionType"/>.</param>
+        public virtual void SetSelectionMethod(int selectionMethodIndex)
+        {
+            SelectionMethod = (SelectionType)Mathf.Clamp(selectionMethodIndex, 0, System.Enum.GetValues(typeof(SelectionType)).Length);
+        }
+
+        /// <summary>
         /// The Activate method turns on the <see cref="ObjectPointer"/>.
         /// </summary>
         [RequiresBehaviourState]


### PR DESCRIPTION
The SelectionType property can now be changed via a UnityEvent by
calling the SetSelectionMethod method and passing in the int to
represent the Enum value to change to.