### PR TITLE
refactor(Facade): use extension method to set enum value

### DIFF
--- a/Runtime/SharedResources/Scripts/PointerFacade.cs
+++ b/Runtime/SharedResources/Scripts/PointerFacade.cs
@@ -9,6 +9,7 @@
     using Zinnia.Action;
     using Zinnia.Cast;
     using Zinnia.Data.Attribute;
+    using Zinnia.Extension;
     using Zinnia.Pointer;
     using Zinnia.Rule;
 
@@ -119,7 +120,7 @@
         /// <param name="selectionMethodIndex">The index of the <see cref="SelectionType"/>.</param>
         public virtual void SetSelectionMethod(int selectionMethodIndex)
         {
-            SelectionMethod = (SelectionType)Mathf.Clamp(selectionMethodIndex, 0, System.Enum.GetValues(typeof(SelectionType)).Length);
+            SelectionMethod = EnumExtensions.GetByIndex<SelectionType>(selectionMethodIndex);
         }
 
         /// <summary>


### PR DESCRIPTION
The SetSelectionMethod method now uses the Zinnia EnumExtensions
helper method to set the value of the enum by the index instead of
repeating the same logic.