### PR TITLE
feat(Facade): add ability to restrict pointer by target point - resolves #66

### DIFF
--- a/Documentation/API/PointerConfigurator.md
+++ b/Documentation/API/PointerConfigurator.md
@@ -21,6 +21,7 @@ Sets up the Pointer Prefab based on the provided user settings.
   * [ConfigureRaycastRules()]
   * [ConfigureSelectionAction()]
   * [ConfigureSelectionType()]
+  * [ConfigureTargetPointValidity()]
   * [ConfigureTargetValidity()]
   * [EmitActivated(ObjectPointer.EventData)]
   * [EmitDeactivated(ObjectPointer.EventData)]
@@ -143,7 +144,7 @@ public virtual void ConfigureFollowSources()
 
 #### ConfigureRaycastRules()
 
-Configures the physics raycast rules based on the facade settings.
+Configures the physics RayCast rules based on the facade settings.
 
 ##### Declaration
 
@@ -169,6 +170,16 @@ Configures the selection type based on the facade settings.
 
 ```
 public virtual void ConfigureSelectionType()
+```
+
+#### ConfigureTargetPointValidity()
+
+Configures the target point validity based on the facade settings.
+
+##### Declaration
+
+```
+public virtual void ConfigureTargetPointValidity()
 ```
 
 #### ConfigureTargetValidity()
@@ -305,6 +316,7 @@ protected virtual void OnEnable()
 [ConfigureRaycastRules()]: #ConfigureRaycastRules
 [ConfigureSelectionAction()]: #ConfigureSelectionAction
 [ConfigureSelectionType()]: #ConfigureSelectionType
+[ConfigureTargetPointValidity()]: #ConfigureTargetPointValidity
 [ConfigureTargetValidity()]: #ConfigureTargetValidity
 [EmitActivated(ObjectPointer.EventData)]: #EmitActivatedObjectPointer.EventData
 [EmitDeactivated(ObjectPointer.EventData)]: #EmitDeactivatedObjectPointer.EventData

--- a/Documentation/API/PointerFacade.md
+++ b/Documentation/API/PointerFacade.md
@@ -21,6 +21,7 @@ The public interface into the Pointer Prefab.
   * [RaycastRules]
   * [SelectionAction]
   * [SelectionMethod]
+  * [TargetPointValidity]
   * [TargetValidity]
 * [Methods]
   * [Activate()]
@@ -30,6 +31,7 @@ The public interface into the Pointer Prefab.
   * [OnAfterRaycastRulesChange()]
   * [OnAfterSelectionActionChange()]
   * [OnAfterSelectionMethodChange()]
+  * [OnAfterTargetPointValidityChange()]
   * [OnAfterTargetValidityChange()]
   * [Select()]
   * [SetSelectionMethod(Int32)]
@@ -147,7 +149,7 @@ public GameObject FollowSource { get; set; }
 
 #### RaycastRules
 
-Allows to optionally define the rules for the raycast of the pointer beam elements.
+Allows to optionally define the rules for the RayCast of the pointer beam elements.
 
 ##### Declaration
 
@@ -173,6 +175,16 @@ The action moment when to initiate the select action.
 
 ```
 public PointerFacade.SelectionType SelectionMethod { get; set; }
+```
+
+#### TargetPointValidity
+
+Allows to optionally determine target point based on the set rules.
+
+##### Declaration
+
+```
+public RuleContainer TargetPointValidity { get; set; }
 ```
 
 #### TargetValidity
@@ -257,6 +269,16 @@ Called after [SelectionMethod] has been changed.
 protected virtual void OnAfterSelectionMethodChange()
 ```
 
+#### OnAfterTargetPointValidityChange()
+
+Called after [TargetPointValidity] has been changed.
+
+##### Declaration
+
+```
+protected virtual void OnAfterTargetPointValidityChange()
+```
+
 #### OnAfterTargetValidityChange()
 
 Called after [TargetValidity] has been changed.
@@ -300,6 +322,7 @@ public virtual void SetSelectionMethod(int selectionMethodIndex)
 [RaycastRules]: PointerFacade.md#RaycastRules
 [SelectionAction]: PointerFacade.md#SelectionAction
 [SelectionMethod]: PointerFacade.md#SelectionMethod
+[TargetPointValidity]: PointerFacade.md#TargetPointValidity
 [TargetValidity]: PointerFacade.md#TargetValidity
 [Selected]: PointerFacade.md#Selected
 [SelectionMethod]: PointerFacade.md#SelectionMethod
@@ -321,6 +344,7 @@ public virtual void SetSelectionMethod(int selectionMethodIndex)
 [RaycastRules]: #RaycastRules
 [SelectionAction]: #SelectionAction
 [SelectionMethod]: #SelectionMethod
+[TargetPointValidity]: #TargetPointValidity
 [TargetValidity]: #TargetValidity
 [Methods]: #Methods
 [Activate()]: #Activate
@@ -330,6 +354,7 @@ public virtual void SetSelectionMethod(int selectionMethodIndex)
 [OnAfterRaycastRulesChange()]: #OnAfterRaycastRulesChange
 [OnAfterSelectionActionChange()]: #OnAfterSelectionActionChange
 [OnAfterSelectionMethodChange()]: #OnAfterSelectionMethodChange
+[OnAfterTargetPointValidityChange()]: #OnAfterTargetPointValidityChange
 [OnAfterTargetValidityChange()]: #OnAfterTargetValidityChange
 [Select()]: #Select
 [SetSelectionMethod(Int32)]: #SetSelectionMethodInt32

--- a/Runtime/SharedResources/Scripts/PointerConfigurator.cs
+++ b/Runtime/SharedResources/Scripts/PointerConfigurator.cs
@@ -81,7 +81,15 @@
         }
 
         /// <summary>
-        /// Configures the physics raycast rules based on the facade settings.
+        /// Configures the target point validity based on the facade settings.
+        /// </summary>
+        public virtual void ConfigureTargetPointValidity()
+        {
+            Caster.TargetPointValidity = Facade.TargetPointValidity;
+        }
+
+        /// <summary>
+        /// Configures the physics RayCast rules based on the facade settings.
         /// </summary>
         public virtual void ConfigureRaycastRules()
         {
@@ -208,6 +216,7 @@
         protected virtual void OnEnable()
         {
             ConfigureTargetValidity();
+            ConfigureTargetPointValidity();
             ConfigureRaycastRules();
             ConfigureFollowSources();
             ConfigureSelectionType();

--- a/Runtime/SharedResources/Scripts/PointerFacade.cs
+++ b/Runtime/SharedResources/Scripts/PointerFacade.cs
@@ -58,14 +58,23 @@
         [Serialized]
         [field: DocumentedByXml]
         public SelectionType SelectionMethod { get; set; }
+        #endregion
+
+        #region Restriction Settings
         /// <summary>
         /// Allows to optionally determine targets based on the set rules.
         /// </summary>
         [Serialized, Cleared]
-        [field: DocumentedByXml]
+        [field: Header("Restriction Settings"), DocumentedByXml]
         public RuleContainer TargetValidity { get; set; }
         /// <summary>
-        /// Allows to optionally define the rules for the raycast of the pointer beam elements.
+        /// Allows to optionally determine target point based on the set rules.
+        /// </summary>
+        [Serialized, Cleared]
+        [field: DocumentedByXml]
+        public RuleContainer TargetPointValidity { get; set; }
+        /// <summary>
+        /// Allows to optionally define the rules for the RayCast of the pointer beam elements.
         /// </summary>
         [Serialized, Cleared]
         [field: DocumentedByXml]
@@ -192,6 +201,15 @@
         protected virtual void OnAfterTargetValidityChange()
         {
             Configuration.ConfigureTargetValidity();
+        }
+
+        /// <summary>
+        /// Called after <see cref="TargetPointValidity"/> has been changed.
+        /// </summary>
+        [CalledAfterChangeOf(nameof(TargetPointValidity))]
+        protected virtual void OnAfterTargetPointValidityChange()
+        {
+            Configuration.ConfigureTargetPointValidity();
         }
 
         /// <summary>


### PR DESCRIPTION
The Zinnia PointsCast now allows to restrict the target point of a
cast to allow or deny certain points of space from being valid.

This is now used with the PointerFacade to allow a pointer to determine
if the point in which the cursor is colliding with is valid based on
a Rule.

It can be used in conjunction with the NavMeshRule to determine if the
pointer is within the bounds of a NavMesh to consider it a valid target
to select.