### PR TITLE
fix(HowToGuides): provide correct worded link to package

### DIFF
--- a/Documentation/HowToGuides/IgnoringColliders/README.md
+++ b/Documentation/HowToGuides/IgnoringColliders/README.md
@@ -16,7 +16,7 @@ We can achieve this by customizing the RayCast of the Object Pointer to determin
 
 ## Prerequisites
 
-* [Add the Tilia.Tilia.Indicators.ObjectPointers.Unity -> Indicators.ObjectPointers.Straight] prefab to the scene hierarchy.
+* [Add the Tilia.Indicators.ObjectPointers.Unity -> Indicators.ObjectPointers.Straight] prefab to the scene hierarchy.
 
 ## Let's Start
 
@@ -100,4 +100,4 @@ Play the Unity scene, activate the Object Pointer by pressing the `Space` key an
 
 ![Pointer Does Not Collide With Cube](assets/images/PointerDoesNotCollideWithCube.png)
 
-[Add the Tilia.Tilia.Indicators.ObjectPointers.Unity -> Indicators.ObjectPointers.Straight]: ../AddingAStraightPointer/README.md
+[Add the Tilia.Indicators.ObjectPointers.Unity -> Indicators.ObjectPointers.Straight]: ../AddingAStraightPointer/README.md

--- a/Documentation/HowToGuides/LimitingToNavMesh/README.md
+++ b/Documentation/HowToGuides/LimitingToNavMesh/README.md
@@ -14,7 +14,7 @@ We can achieve this by using a [Zinnia] rule.
 
 ## Prerequisites
 
-* [Add the Tilia.Tilia.Indicators.ObjectPointers.Unity -> Indicators.ObjectPointers.Straight] prefab to the scene hierarchy.
+* [Add the Tilia.Indicators.ObjectPointers.Unity -> Indicators.ObjectPointers.Straight] prefab to the scene hierarchy.
 
 ## Let's Start
 
@@ -72,4 +72,4 @@ Play the Unity scene, activate the Object Pointer by pressing the `Space` key an
 
 [Unity NavMesh]: https://docs.unity3d.com/ScriptReference/AI.NavMesh.html
 [Zinnia]: https://github.com/ExtendRealityLtd/Zinnia.Unity
-[Add the Tilia.Tilia.Indicators.ObjectPointers.Unity -> Indicators.ObjectPointers.Straight]: ../AddingAStraightPointer/README.md
+[Add the Tilia.Indicators.ObjectPointers.Unity -> Indicators.ObjectPointers.Straight]: ../AddingAStraightPointer/README.md

--- a/Documentation/HowToGuides/SettingInvalidTargets/README.md
+++ b/Documentation/HowToGuides/SettingInvalidTargets/README.md
@@ -16,7 +16,7 @@ We can achieve this by using the [Zinnia] rules to determine which targets are c
 
 ## Prerequisites
 
-* [Add the Tilia.Tilia.Indicators.ObjectPointers.Unity -> Indicators.ObjectPointers.Straight] prefab to the scene hierarchy.
+* [Add the Tilia.Indicators.ObjectPointers.Unity -> Indicators.ObjectPointers.Straight] prefab to the scene hierarchy.
 
 ## Let's Start
 
@@ -94,4 +94,4 @@ Play the Unity scene, activate the Object Pointer by pressing the `Space` key an
 ![Pointer Sees Cube As Invalid Target](assets/images/PointerSeesCubeAsInvalidTarget.png)
 
 [Zinnia]: https://github.com/ExtendRealityLtd/Zinnia.Unity
-[Add the Tilia.Tilia.Indicators.ObjectPointers.Unity -> Indicators.ObjectPointers.Straight]: ../AddingAStraightPointer/README.md
+[Add the Tilia.Indicators.ObjectPointers.Unity -> Indicators.ObjectPointers.Straight]: ../AddingAStraightPointer/README.md


### PR DESCRIPTION
The link to the ObjectPointers package had a `Tilia` twice in the path
whereas it only needs to have it in there once.