### PR TITLE
fix(package.json): add missing reference to Editor directory

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
         "*.xml",
         "Documentation",
         "Runtime",
+        "Editor",
         "docfx.json"
     ]
 }


### PR DESCRIPTION
The build will fail without referencing this new Editor directory
so it has now been added to the package.