### PR TITLE
feat(Facade): add hover validity setting

### DIFF
--- a/Documentation/API/PointerConfigurator.md
+++ b/Documentation/API/PointerConfigurator.md
@@ -29,6 +29,7 @@ Sets up the Pointer Prefab based on the provided user settings.
   * [EmitExited(ObjectPointer.EventData)]
   * [EmitHoverChanged(ObjectPointer.EventData)]
   * [EmitSelected(ObjectPointer.EventData)]
+  * [IsValidHover(ObjectPointer.EventData)]
   * [OnEnable()]
 
 ## Details
@@ -288,6 +289,28 @@ public virtual void EmitSelected(ObjectPointer.EventData eventData)
 | --- | --- | --- |
 | ObjectPointer.EventData | eventData | The data to emit. |
 
+#### IsValidHover(ObjectPointer.EventData)
+
+Determines whether the current event data is hovering over a valid target.
+
+##### Declaration
+
+```
+protected virtual bool IsValidHover(ObjectPointer.EventData eventData)
+```
+
+##### Parameters
+
+| Type | Name | Description |
+| --- | --- | --- |
+| ObjectPointer.EventData | eventData | The hover data. |
+
+##### Returns
+
+| Type | Description |
+| --- | --- |
+| System.Boolean | Whether the hover data is valid. |
+
 #### OnEnable()
 
 ##### Declaration
@@ -324,4 +347,5 @@ protected virtual void OnEnable()
 [EmitExited(ObjectPointer.EventData)]: #EmitExitedObjectPointer.EventData
 [EmitHoverChanged(ObjectPointer.EventData)]: #EmitHoverChangedObjectPointer.EventData
 [EmitSelected(ObjectPointer.EventData)]: #EmitSelectedObjectPointer.EventData
+[IsValidHover(ObjectPointer.EventData)]: #IsValidHoverObjectPointer.EventData
 [OnEnable()]: #OnEnable

--- a/Documentation/API/PointerFacade.md
+++ b/Documentation/API/PointerFacade.md
@@ -18,6 +18,7 @@ The public interface into the Pointer Prefab.
   * [ActivationAction]
   * [Configuration]
   * [FollowSource]
+  * [HoverValidity]
   * [RaycastRules]
   * [SelectionAction]
   * [SelectionMethod]
@@ -153,6 +154,16 @@ The source for the pointer origin to follow.
 public GameObject FollowSource { get; set; }
 ```
 
+#### HoverValidity
+
+Allows to optionally determine targets based on the set rules.
+
+##### Declaration
+
+```
+public RuleContainer HoverValidity { get; set; }
+```
+
 #### RaycastRules
 
 Allows to optionally define the rules for the RayCast of the pointer beam elements.
@@ -185,7 +196,7 @@ public PointerFacade.SelectionType SelectionMethod { get; set; }
 
 #### TargetPointValidity
 
-Allows to optionally determine a specific target point based on the set rules.
+Allows to optionally determine a specific selection target point based on the set rules.
 
 ##### Declaration
 
@@ -195,7 +206,7 @@ public RuleContainer TargetPointValidity { get; set; }
 
 #### TargetValidity
 
-Allows to optionally determine targets based on the set rules.
+Allows to optionally determine selection targets based on the set rules.
 
 ##### Declaration
 
@@ -413,6 +424,7 @@ public virtual void SetSelectionMethod(int selectionMethodIndex)
 [ActivationAction]: #ActivationAction
 [Configuration]: #Configuration
 [FollowSource]: #FollowSource
+[HoverValidity]: #HoverValidity
 [RaycastRules]: #RaycastRules
 [SelectionAction]: #SelectionAction
 [SelectionMethod]: #SelectionMethod

--- a/Runtime/SharedResources/Scripts/PointerConfigurator.cs
+++ b/Runtime/SharedResources/Scripts/PointerConfigurator.cs
@@ -270,6 +270,11 @@
         /// <param name="eventData">The data to emit.</param>
         public virtual void EmitEntered(ObjectPointer.EventData eventData)
         {
+            if (!IsValidHover(eventData))
+            {
+                return;
+            }
+
             Facade.Entered?.Invoke(eventData);
         }
 
@@ -279,6 +284,11 @@
         /// <param name="eventData">The data to emit.</param>
         public virtual void EmitExited(ObjectPointer.EventData eventData)
         {
+            if (!IsValidHover(eventData))
+            {
+                return;
+            }
+
             Facade.Exited?.Invoke(eventData);
         }
 
@@ -288,6 +298,11 @@
         /// <param name="eventData">The data to emit.</param>
         public virtual void EmitHoverChanged(ObjectPointer.EventData eventData)
         {
+            if (!IsValidHover(eventData))
+            {
+                return;
+            }
+
             Facade.HoverChanged?.Invoke(eventData);
         }
 
@@ -307,6 +322,20 @@
             ConfigureRaycastRules();
             ConfigureFollowSources();
             ConfigureSelectionType();
+        }
+
+        /// <summary>
+        /// Determines whether the current event data is hovering over a valid target.
+        /// </summary>
+        /// <param name="eventData">The hover data.</param>
+        /// <returns>Whether the hover data is valid.</returns>
+        protected virtual bool IsValidHover(ObjectPointer.EventData eventData)
+        {
+            return eventData != null &&
+                eventData.CurrentPointsCastData != null &&
+                eventData.CurrentPointsCastData.HitData != null &&
+                eventData.CurrentPointsCastData.HitData.Value.transform != null &&
+                Facade.HoverValidity.Accepts(eventData.CurrentPointsCastData.HitData.Value.transform.gameObject);
         }
     }
 }

--- a/Runtime/SharedResources/Scripts/PointerFacade.cs
+++ b/Runtime/SharedResources/Scripts/PointerFacade.cs
@@ -120,9 +120,26 @@
         [Header("Restriction Settings")]
         [Tooltip("Allows to optionally determine targets based on the set rules.")]
         [SerializeField]
-        private RuleContainer targetValidity;
+        private RuleContainer hoverValidity;
         /// <summary>
         /// Allows to optionally determine targets based on the set rules.
+        /// </summary>
+        public RuleContainer HoverValidity
+        {
+            get
+            {
+                return hoverValidity;
+            }
+            set
+            {
+                hoverValidity = value;
+            }
+        }
+        [Tooltip("Allows to optionally determine selection targets based on the set rules.")]
+        [SerializeField]
+        private RuleContainer targetValidity;
+        /// <summary>
+        /// Allows to optionally determine selection targets based on the set rules.
         /// </summary>
         public RuleContainer TargetValidity
         {
@@ -139,11 +156,11 @@
                 }
             }
         }
-        [Tooltip("Allows to optionally determine a specific target point based on the set rules.")]
+        [Tooltip("Allows to optionally determine a specific selection target point based on the set rules.")]
         [SerializeField]
         private RuleContainer targetPointValidity;
         /// <summary>
-        /// Allows to optionally determine a specific target point based on the set rules.
+        /// Allows to optionally determine a specific selection target point based on the set rules.
         /// </summary>
         public RuleContainer TargetPointValidity
         {


### PR DESCRIPTION
The new Hover Validity restriction setting can be used to determine
which objects can be considered valid for hover actions such as
entered, exitit and hover changed. The Rule will simply block the
Facade events from emitting and won't change any internal states.